### PR TITLE
Update the repository URL in the README file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # ****************************************************************************
-#    Ledger App Boilerplate
+#    Ledger App
 #    (c) 2023 Ledger SAS.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd plugin_dev
 Inside `plugin_dev`, clone the plugin repository (including submodules):
 
 ```shell
-git clone --recurse-submodules git@github.com:figment-networks/ledger-app-plugin.git
+git clone --recurse-submodules https://github.com/figment-networks/ledger-app-plugin
 ```
 
 You can compile the plugin using a Docker image provided by Ledger.


### PR DESCRIPTION
Since the repository is public, we need to adjust the repository URL in the README file.