### PR TITLE
[SECOPS-2289] Hash pinning on GitHub Actions workflows #sec

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
 
@@ -44,7 +44,7 @@ jobs:
       image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
 
@@ -52,7 +52,7 @@ jobs:
         run: |
           scan-build --use-cc=clang -analyze-headers -enable-checker security -enable-checker unix -enable-checker valist -o scan-build --status-bugs make default
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         if: failure()
         with:
           name: scan-build
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
 
@@ -89,7 +89,7 @@ jobs:
           mv bin/app.elf plugin_${{ matrix.name }}.elf
 
       - name: Upload binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: binaries
           path: plugin_${{ matrix.name }}.elf
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Checkout app-ethereum
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: LedgerHQ/app-ethereum
 
@@ -125,7 +125,7 @@ jobs:
           mv bin/app.elf ethereum_${{ matrix.name }}.elf
 
       - name: Upload binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: binaries
           path: ethereum_${{ matrix.name }}.elf
@@ -144,16 +144,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Download built binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: binaries
           path: tests/elfs/
 
       - name: Install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: "16.19.0"
 

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:v2.0.0
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 
     steps:
       - name: Clone
@@ -41,7 +41,7 @@ jobs:
     name: Clang Static Analyzer
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:v2.0.0
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
@@ -72,7 +72,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:v2.0.0
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 
     steps:
       - name: Clone
@@ -108,7 +108,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:v2.0.0
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
 
     steps:
       - name: Checkout app-ethereum

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -52,11 +52,7 @@ jobs:
         run: |
           scan-build --use-cc=clang -analyze-headers -enable-checker security -enable-checker unix -enable-checker valist -o scan-build --status-bugs make default
 
-<<<<<<< HEAD
-      - uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
-=======
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
->>>>>>> 81274ee ([SECOPS-2289] Enforce hash pinning on GitHub Actions workflows #sec)
         if: failure()
         with:
           name: scan-build
@@ -93,11 +89,7 @@ jobs:
           mv bin/app.elf plugin_${{ matrix.name }}.elf
 
       - name: Upload binary
-<<<<<<< HEAD
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
-=======
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
->>>>>>> 81274ee ([SECOPS-2289] Enforce hash pinning on GitHub Actions workflows #sec)
         with:
           name: binaries
           path: plugin_${{ matrix.name }}.elf
@@ -133,11 +125,7 @@ jobs:
           mv bin/app.elf ethereum_${{ matrix.name }}.elf
 
       - name: Upload binary
-<<<<<<< HEAD
-        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
-=======
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
->>>>>>> 81274ee ([SECOPS-2289] Enforce hash pinning on GitHub Actions workflows #sec)
         with:
           name: binaries
           path: ethereum_${{ matrix.name }}.elf
@@ -159,11 +147,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Download built binaries
-<<<<<<< HEAD
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
-=======
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
->>>>>>> 81274ee ([SECOPS-2289] Enforce hash pinning on GitHub Actions workflows #sec)
         with:
           name: binaries
           path: tests/elfs/

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -52,7 +52,11 @@ jobs:
         run: |
           scan-build --use-cc=clang -analyze-headers -enable-checker security -enable-checker unix -enable-checker valist -o scan-build --status-bugs make default
 
+<<<<<<< HEAD
       - uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+=======
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+>>>>>>> 81274ee ([SECOPS-2289] Enforce hash pinning on GitHub Actions workflows #sec)
         if: failure()
         with:
           name: scan-build
@@ -89,7 +93,11 @@ jobs:
           mv bin/app.elf plugin_${{ matrix.name }}.elf
 
       - name: Upload binary
+<<<<<<< HEAD
         uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+=======
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+>>>>>>> 81274ee ([SECOPS-2289] Enforce hash pinning on GitHub Actions workflows #sec)
         with:
           name: binaries
           path: plugin_${{ matrix.name }}.elf
@@ -125,7 +133,11 @@ jobs:
           mv bin/app.elf ethereum_${{ matrix.name }}.elf
 
       - name: Upload binary
+<<<<<<< HEAD
         uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
+=======
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+>>>>>>> 81274ee ([SECOPS-2289] Enforce hash pinning on GitHub Actions workflows #sec)
         with:
           name: binaries
           path: ethereum_${{ matrix.name }}.elf
@@ -147,7 +159,11 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Download built binaries
+<<<<<<< HEAD
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+=======
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+>>>>>>> 81274ee ([SECOPS-2289] Enforce hash pinning on GitHub Actions workflows #sec)
         with:
           name: binaries
           path: tests/elfs/

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:v2.0.0
 
     steps:
       - name: Clone
@@ -41,7 +41,7 @@ jobs:
     name: Clang Static Analyzer
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:v2.0.0
 
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
@@ -72,7 +72,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:v2.0.0
 
     steps:
       - name: Clone
@@ -108,7 +108,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest
+      image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:v2.0.0
 
     steps:
       - name: Checkout app-ethereum

--- a/.github/workflows/guidelines_enforcer.yml
+++ b/.github/workflows/guidelines_enforcer.yml
@@ -19,5 +19,5 @@ on:
 jobs:
   guidelines_enforcer:
     name: Call Ledger guidelines_enforcer
-    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_guidelines_enforcer.yml@v1
+    uses: LedgerHQ/ledger-app-workflows/.github/workflows/reusable_guidelines_enforcer.yml@2e93bf5fb49bbab4ddcb3f59e313ce9bb7d78314 # v1
     if: github.repository_owner == 'LedgerHQ'

--- a/.github/workflows/lint-workflow.yml
+++ b/.github/workflows/lint-workflow.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Lint
-        uses: DoozyX/clang-format-lint-action@v0.15
+        uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.15
         with:
           source: "./"
           extensions: "h,c"


### PR DESCRIPTION
Pin actions/checkout, upload-artifact, download-artifact, setup-node, DoozyX/clang-format-lint-action, LedgerHQ reusable workflow to commit SHAs.